### PR TITLE
[WIP] Provide a "globals" option

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -37,8 +37,11 @@ export const engines = Object.values(enginesDict);
 
 export type Engine = keyof typeof enginesDict;
 
+export type Globals = { [key: string]: any };
+
 export type Config = {
   engine?: Engine;
+  globals?: string | Globals,
   templates?: Template[];
   templateFiles?: string[];
 };

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -6,6 +6,7 @@ import * as fse from "fs-extra";
 import { getCurrentRoot, getEngine, getFolderPath } from "./utils";
 import { maybeRender, render } from "./render";
 import ask from "./ask-questions";
+import getGlobals from "./get-globals";
 import getTemplate from "./get-template";
 
 async function newFromTemplate(uri: Uri | undefined) {
@@ -15,7 +16,7 @@ async function newFromTemplate(uri: Uri | undefined) {
   if (!template) return;
 
   const engine = getEngine(root);
-  const answers = await ask(template.questions);
+  const answers = {...getGlobals(root), ...await ask(template.questions)};
 
   if (!answers) return;
 

--- a/source/get-globals.ts
+++ b/source/get-globals.ts
@@ -1,0 +1,14 @@
+import { readJson, getConfig } from "./utils";
+import { WorkspaceFolder } from "vscode";
+import { Globals } from "./config";
+
+export default function getGlobals(root: WorkspaceFolder): Globals {
+    let globals = getConfig(root).globals ?? {};
+    if ('string' === typeof globals) {
+        globals = readJson(root, globals) as Globals;
+    }
+
+    // TODO provide global variables like "workspaceName" and locally scoped like "dir" and "dirRelative"
+
+    return globals;
+}


### PR DESCRIPTION
This PR is a WIP and allows the following:

```json
"module-templates.globals": "../package.json"
```

or:

```json
"module-templates.globals": {
  "author": "marco Polichetti"
}
```

- Don't know if it works with legacy template engine
- Maybe rename to "values" instead of "globals" like https://marketplace.visualstudio.com/items?itemName=ego-digital.vscode-powertools
- Make it work relative to the workspace dir, i.e. avoid `../` in path
- Maybe allow multiple files? Like globals: `["package.json", "composer.json"]` with a merging strategy (the last win)
- Provide some predefined globals like (table below) or directory where the "New from template" is invoked

| Name | Description |
| ---- | ----------- |
| `workspaceId` | The ID of the workspace. |
| `workspaceIndex` | The zero based index of the [workspace folder](https://code.visualstudio.com/api/references/vscode-api#WorkspaceFolder). |
| `workspaceName` | The name of the [workspace folder](https://code.visualstudio.com/api/references/vscode-api#WorkspaceFolder). |
| `workspaceRoot` | The root path of the workspace. |
| `workspaceUri` | The [URI](https://code.visualstudio.com/api/references/vscode-api#Uri) of the [workspace folder](https://code.visualstudio.com/api/references/vscode-api#WorkspaceFolder). |
