### PR TITLE
Make sure `open` doesn't open a preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+- Fixes bug to make sure `open` actually opens all the files.
+
 ## 1.3.0
 
 - Adds `open` option to files for automatically opening them after creation.

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -32,7 +32,7 @@ async function newFromTemplate(uri: Uri | undefined) {
     if (open) {
       workspace
         .openTextDocument(Uri.file(filePath))
-        .then(window.showTextDocument);
+        .then(doc => window.showTextDocument(doc, { preview: false }));
     }
   });
 }


### PR DESCRIPTION
Currently, only the last file is being opened.

Btw, I have explored and tried all the templating extensions on the whole VS Code marketplace and I can confidently say that this is the best one.