### PR TITLE
Fix `handlebarsConfig` file not found (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.4
+
+- Fix `handlebarsConfig` file not found even when path is correct, for Windows
+
 ## 1.9.3
 
 - Fix `handlebarsConfig` file not found even when path is correct

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Module Templates",
   "publisher": "asbjornh",
   "icon": "icon.png",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "A VSCode extension for creating file/folder templates for new modules",
   "scripts": {
     "vscode:prepublish": "webpack",
@@ -20,10 +20,10 @@
     "@types/handlebars": "^4.1.0",
     "@types/node": "^13.1.6",
     "@types/vscode": "^1.41.0",
-    "ts-loader": "^6.2.1",
+    "ts-loader": "^9.4.2",
     "typescript": "^4.3.5",
-    "webpack": "^4.41.5",
-    "webpack-cli": "^3.3.10",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1",
     "webpack-event-plugin": "^1.1.1"
   },
   "repository": {

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -79,10 +79,10 @@ export function getEngine(root: WorkspaceFolder): Engine {
   return engine;
 }
 
-const tryRequire = (path: string) => {
+const tryRequire = (pathString: string) => {
   try {
     // NOTE: Webpack does some shenanigans with `require` building (this does not happen when debugging the extension in VSCode)
-    return eval(`require("${path}")`);
+    return eval(`require("${pathString}")`.replace(/\\/g, "/"));
   } catch (error) {
     throw new Error(
       `${error.name}: ${error.message} in ${error.stack.split("\n")[0]}`,


### PR DESCRIPTION
See comment on issue #26
- Regex replace backslashes with forward slashes in the path string to the config file
- Rename parameter 'path' to 'pathString' to distinguish from the path library declared in the file